### PR TITLE
Fallback to known feeder model if absent in API

### DIFF
--- a/custom_components/petsafe/ButtonEntities.py
+++ b/custom_components/petsafe/ButtonEntities.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import petsafe
 
 from . import PetSafeCoordinator
-from .const import DOMAIN, MANUFACTURER
+from .const import DOMAIN, FEEDER_MODEL_GEN1, MANUFACTURER
 
 
 class PetSafeButtonEntity(CoordinatorEntity, ButtonEntity):
@@ -100,7 +100,7 @@ class PetSafeFeederButtonEntity(PetSafeButtonEntity):
             manufacturer=MANUFACTURER,
             name=device.friendly_name,
             sw_version=device.firmware,
-            model=device.product_name,
+            model=device.product_name or FEEDER_MODEL_GEN1,
         )
 
     async def async_press(self) -> None:

--- a/custom_components/petsafe/SensorEntities.py
+++ b/custom_components/petsafe/SensorEntities.py
@@ -15,6 +15,8 @@ from .const import (
     CAT_IN_BOX,
     DOMAIN,
     ERROR_SENSOR_BLOCKED,
+    FEEDER_MODEL_GEN1,
+    FEEDER_MODEL_GEN2,
     MANUFACTURER,
     RAKE_BUTTON_DETECTED,
     RAKE_FINISHED,
@@ -187,7 +189,8 @@ class PetSafeFeederSensorEntity(PetSafeSensorEntity):
             manufacturer=MANUFACTURER,
             name=device.friendly_name,
             sw_version=device.firmware,
-            model=device.product_name,
+            # NB: Gen1 smart feeders do not report a product_name
+            model=device.product_name or FEEDER_MODEL_GEN1,
         )
 
         if self._device_type == "last_feeding":

--- a/custom_components/petsafe/SwitchEntities.py
+++ b/custom_components/petsafe/SwitchEntities.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import petsafe
 
 from . import PetSafeCoordinator, PetSafeData
-from .const import DOMAIN, MANUFACTURER
+from .const import DOMAIN, FEEDER_MODEL_GEN1, MANUFACTURER
 
 
 class PetSafeSwitchEntity(CoordinatorEntity, SwitchEntity):
@@ -109,7 +109,8 @@ class PetSafeFeederSwitchEntity(PetSafeSwitchEntity):
             manufacturer=MANUFACTURER,
             name=device.friendly_name,
             sw_version=device.firmware,
-            model=device.product_name,
+            # NB: Gen1 smart feeders do not report a product_name
+            model=device.product_name or FEEDER_MODEL_GEN1,
         )
         self._device = device
 

--- a/custom_components/petsafe/const.py
+++ b/custom_components/petsafe/const.py
@@ -3,7 +3,8 @@
 DOMAIN = "petsafe"
 CONF_REFRESH_TOKEN = "refresh_token"
 MANUFACTURER = "PetSafe"
-FEEDER_MODEL = "SmartFeed_2.0"
+FEEDER_MODEL_GEN1 = "SmartFeed_1.0"
+FEEDER_MODEL_GEN2 = "SmartFeed_2.0"
 
 SERVICE_ADD_SCHEDULE = "add_schedule"
 SERVICE_DELETE_SCHEDULE = "delete_schedule"

--- a/custom_components/petsafe/helpers.py
+++ b/custom_components/petsafe/helpers.py
@@ -3,7 +3,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.device_registry import DeviceEntry, DeviceRegistry
 
-from .const import DOMAIN, FEEDER_MODEL
+from .const import DOMAIN, FEEDER_MODEL_GEN1, FEEDER_MODEL_GEN2
 
 
 def get_feeders_for_service(hass: HomeAssistant, area_ids, device_ids, entity_ids):
@@ -90,7 +90,7 @@ def get_feeders_by_entity_id(
 
 
 def is_device_feeder(hass: HomeAssistant, device: DeviceEntry):
-    if device.model != FEEDER_MODEL:
+    if device.model not in [FEEDER_MODEL_GEN1, FEEDER_MODEL_GEN2]:
         return False
 
     config_entry_ids = device.config_entries

--- a/custom_components/petsafe/services.yaml
+++ b/custom_components/petsafe/services.yaml
@@ -4,7 +4,6 @@ add_schedule:
   target:
     device:
       integration: petsafe
-      model: SmartFeed_2.0
     entity:
       integration: petsafe
   fields:
@@ -29,7 +28,6 @@ delete_schedule:
   target:
     device:
       integration: petsafe
-      model: SmartFeed_2.0
     entity:
       integration: petsafe
   fields:
@@ -46,7 +44,6 @@ delete_all_schedules:
   target:
     device:
       integration: petsafe
-      model: SmartFeed_2.0
     entity:
       integration: petsafe
 
@@ -56,7 +53,6 @@ modify_schedule:
   target:
     device:
       integration: petsafe
-      model: SmartFeed_2.0
     entity:
       integration: petsafe
   fields:
@@ -81,7 +77,6 @@ feed:
   target:
     device:
       integration: petsafe
-      model: SmartFeed_2.0
     entity:
       integration: petsafe
   fields:
@@ -106,6 +101,5 @@ prime:
   target:
     device:
       integration: petsafe
-      model: SmartFeed_2.0
     entity:
       integration: petsafe


### PR DESCRIPTION
Fixes #4, in the simpler / less pretty way, by assigning `SmartFeed_2.0` as the model for *any* feeder that has a `null` `product_name`.

This does work, but I'm happy to rework it to a different approach or have you do the same if you prefer!