### PR TITLE
Feature: Add Feed and Prime services

### DIFF
--- a/custom_components/petsafe/const.py
+++ b/custom_components/petsafe/const.py
@@ -9,9 +9,12 @@ SERVICE_ADD_SCHEDULE = "add_schedule"
 SERVICE_DELETE_SCHEDULE = "delete_schedule"
 SERVICE_DELETE_ALL_SCHEDULES = "delete_all_schedules"
 SERVICE_MODIFY_SCHEDULE = "modify_schedule"
+SERVICE_FEED = "feed"
+SERVICE_PRIME = "prime"
 
 ATTR_TIME = "time"
 ATTR_AMOUNT = "amount"
+ATTR_SLOW_FEED = "slow_feed"
 
 RAKE_FINISHED = "RAKE_FINISHED"
 CAT_IN_BOX = "CAT_IN_BOX"

--- a/custom_components/petsafe/services.yaml
+++ b/custom_components/petsafe/services.yaml
@@ -74,3 +74,38 @@ modify_schedule:
         number:
           min: 1
           max: 32
+
+feed:
+  name: Feed a meal
+  description: Trigger the feeder to begin feeding a meal
+  target:
+    device:
+      integration: petsafe
+      model: SmartFeed_2.0
+    entity:
+      integration: petsafe
+  fields:
+    amount:
+      name: Amount
+      description: The feeding amount in 1/8 cup
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 32
+    slow_feed:
+      name: Slow Feed
+      description: Whether to use slow feed mode. If not specified, uses the current feeder setting.
+      required: false
+      selector:
+        boolean:
+
+prime:
+  name: Prime the feeder
+  description: Feeds 5/8 cups to prime the feeder
+  target:
+    device:
+      integration: petsafe
+      model: SmartFeed_2.0
+    entity:
+      integration: petsafe


### PR DESCRIPTION
I'd like to propose adding these two services to the integration:

* `feed`: Trigger a custom meal size and optional slow feed setting
* `prime`: Trigger a 5/8 cup meal to prime the feeder's conveyor belt, e.g. after refilling an empty feeder

`feed` has some overlap with the `ButtonEntity` for the smart feeder, however it allows automations more flexibility in sending different amounts of food, with or without slow feed. By contrast the `ButtonEntity`'s behavior makes sense as-is. It mirrors pushing the physical button.

The use case for `prime` is probably self-explanatory, and adding it to the HA integration is mostly convenience to consolidate down to one smart home app 😁 

My use case for `feed` is: At our house we have a scheduled morning feed for our cats, but we manually trigger their larger dinner feed after brushing the cats' teeth each afternoon. This usually works well, but sometimes on weekends we'll be out of the house during normal meal time and forget to feed the cats until our return... I'd love to write an HA automation that checks the `Last Feeding` entity to make sure that if **we** haven't fed the cats by a certain time, then HA will trigger their 4/8 cup meal automatically as a backup. 😹 

(Note: I've only tested on my first gen smart feeder, and only _with_ the patch from #5 as well. Would be good to test on a 2nd gen feeder.)