### PR TITLE
Add next_feeding sensor

### DIFF
--- a/custom_components/petsafe/SensorEntities.py
+++ b/custom_components/petsafe/SensorEntities.py
@@ -239,8 +239,9 @@ class PetSafeFeederSensorEntity(PetSafeSensorEntity):
             feeder: petsafe.devices.DeviceSmartFeed = next(
                 x for x in data.feeders if x.api_name == self._api_name
             )
-            schedules = await feeder.get_schedules()
-            self._attr_native_value = self._get_next_feeding_time(schedules)
+            if self._attr_native_value is None or dt_util.now() > self._attr_native_value:
+                schedules = await feeder.get_schedules()
+                self._attr_native_value = self._get_next_feeding_time(schedules)
         return await super().async_update()
     
     def _get_next_feeding_time(self, schedules):

--- a/custom_components/petsafe/sensor.py
+++ b/custom_components/petsafe/sensor.py
@@ -46,6 +46,16 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry, add_entiti
         entities.append(
             SensorEntities.PetSafeFeederSensorEntity(
                 hass=hass,
+                name="Next Feeding",
+                device_type="next_feeding",
+                device_class="timestamp",
+                device=feeder,
+                coordinator=coordinator,
+            )
+        )
+        entities.append(
+            SensorEntities.PetSafeFeederSensorEntity(
+                hass=hass,
                 name="Food Level",
                 device_type="food_level",
                 device=feeder,


### PR DESCRIPTION
## Description

This pull request adds a new sensor for `next_feeding` to the PetSafe integration in Home Assistant. The changes include:

- adds a new  `PetSafeFeederSensorEntity` whose purpose is to track the timestamp of the next scheduled feeding
- adds logic  to calculate and return the next scheduled feeding time 

![Screenshot 2024-12-29 143511](https://github.com/user-attachments/assets/052c6521-f5ff-4b51-8af1-0a76c2ced3c7)

I'm using this to facilitate the ability to skip the next feeding (by pausing the feeder until after the next scheduled feeding time and then unpausing it) with a script like this:

```
alias: Skip Next Feeding
sequence:
  - condition: state
    entity_id: switch.feed_your_head_feeding_paused
    state: "off"
  - action: switch.turn_on
    target:
      entity_id: switch.feed_your_head_feeding_paused
  - variables:
      delay_seconds: >-
        {% set next_feeding = states('sensor.feed_your_head_next_feeding') |
        as_timestamp %}  {% set current_time = now() | as_timestamp %}   
        {{(next_feeding - current_time) + 30 if next_feeding > current_time else
        0 }}
  - delay:
      seconds: "{{ delay_seconds }}"
  - action: switch.turn_off
    target:
      entity_id: switch.feed_your_head_feeding_paused
```  